### PR TITLE
split front matter from markdown (compatiblity with jekyll)

### DIFF
--- a/MarkReport/md-parsing.go
+++ b/MarkReport/md-parsing.go
@@ -81,7 +81,7 @@ func splitMarkDownFrontMatter(input string) (markdown string, front_matter *Data
 	return md, &yamlData
 }
 
-func getMarkdownContent(dir string) ([]byte, Data) {
+func getMarkdownContent(dir string) ([]byte, *Data) {
 	d, _ := os.Open(dir)
 	files, _ := d.Readdir(-1)
 	d.Close()
@@ -96,7 +96,7 @@ func getMarkdownContent(dir string) ([]byte, Data) {
 	}
 
 	if len(mdFiles) == 0 {
-		return []byte{}, Data{}
+		return []byte{}, nil
 	}
 
 	// Look for content.txt
@@ -124,7 +124,8 @@ func getMarkdownContent(dir string) ([]byte, Data) {
 	}
 
 	mdContent := ""
-	data := Data{}
+	var data *Data
+
 	for _, f := range mdFilesPicked {
 		if (f == ".md") {
 			continue
@@ -135,7 +136,7 @@ func getMarkdownContent(dir string) ([]byte, Data) {
 		}
 		cMD, cFrontMatter := splitMarkDownFrontMatter(string(c))
 		if cFrontMatter != nil {
-			data = *cFrontMatter
+			data = cFrontMatter
 		}
 		mdContent += "\n\n" + cMD
 	}
@@ -151,7 +152,14 @@ func main() {
 	}
 	dir := os.Args[1]
 
-	mdContent, data := getMarkdownContent(dir)
+	var data Data
+	data.Header = true
+
+	mdContent, yamlData := getMarkdownContent(dir)
+
+	if yamlData != nil {
+		data = *yamlData
+	}
 
 //	fmt.Printf("data: %v\n\n", data)
 

--- a/MarkReport/md-parsing.go
+++ b/MarkReport/md-parsing.go
@@ -51,6 +51,25 @@ var commentToHTML = map[string]string{
 
 var figNum = 1
 
+// split front matter from markdown (see jekyll)
+func splitMarkDownFrontMatter(input string) (markdown string, front_matter string) {
+	re, _ := regexp.Compile(`---`)
+	res := re.FindAllStringSubmatchIndex(input, -1)
+
+	// must contain at least two occurances of ---
+	if len(res) < 2 {
+		return input, string("")
+	}
+
+	// it must be on the begining of the document
+	if res[0][0] != 0 {
+		return input, string("")
+	}
+	front := input[res[0][1]:res[1][0]]
+	md := input[res[1][1]:]
+	return md, front
+}
+
 func getMarkdownContent(dir string) []byte {
 	d, _ := os.Open(dir)
 	files, _ := d.Readdir(-1)
@@ -102,13 +121,19 @@ func getMarkdownContent(dir string) []byte {
 		if err != nil {
 			panic(err)
 		}
-		mdContent += "\n\n" + string(c)
+		cMD, _ := splitMarkDownFrontMatter(string(c))
+		mdContent += "\n\n" + cMD
 	}
 
 	return []byte(mdContent)
 }
 
 func main() {
+
+	if (len(os.Args) != 2) {
+		print("usage: " + os.Args[0] + " directory\n")
+		return
+	}
 	dir := os.Args[1]
 
 	mdContent := getMarkdownContent(dir)

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Compilation of md-parsing
 
     export GOPATH=~/.go
     go get gopkg.in/russross/blackfriday.v2
+    go get gopkg.in/yaml.v2
     go build -i md-parsing.go
 
 The firefox driver is used to interpret JavaScript inside the HTML page generated from Markdown. You need to grab `geckodriver` in order to make it work:


### PR DESCRIPTION
Jekyll flawored Markdown documents could contain [front matter](https://jekyllrb.com/docs/front-matter/) which is YAML configuration prefixed into document. It allows customization of the web page. For example:
```
---
layout: post
title: Blogging Like a Hacker
---
# Blogging Like a Hacker
content
```
This could be used to define "Data" variables like title, etc.